### PR TITLE
src/CMakeLists.txt: Deleted non-existent header from CMakeLists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,6 @@ set (tinyb_LIB_SRCS
 )
 
 set (tinyb_LIB_GLOB_HEADERS
-  ${PROJECT_SOURCE_DIR}/api/tinyb.h
   ${PROJECT_SOURCE_DIR}/api/tinyb.hpp
 )
 


### PR DESCRIPTION
Signed-off-by: Andrei Vasiliu <andrei.vasiliu@intel.com>