### PR TITLE
Add OSGI manifest metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ string (REGEX REPLACE "^v[0-9]+\\.[0-9]+\\.[0-9]+\\-([0-9]+).*" "\\1" VERSION_CO
 string (REGEX REPLACE "^v[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+\\-(.*)" "\\1" VERSION_SHA1 "${VERSION}")
 set (VERSION_SHORT "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 set (VERSION_API "${VERSION_MAJOR}.${VERSION_MINOR}")
+string(TIMESTAMP BUILD_TSTAMP "%Y-%m-%d %H:%M:%S")
 
 if ("${VERSION_COMMIT}" MATCHES "^v.*")
   set (VERSION_COMMIT "")

--- a/java/manifest.txt.in
+++ b/java/manifest.txt.in
@@ -1,10 +1,16 @@
-Manifest-version: 1.0
+Manifest-Version: 1.0
+Bundle-Date: @BUILD_TSTAMP@
+Bundle-ManifestVersion: 2
+Bundle-Name: tinyb
+Bundle-SymbolicName: tinyb
+Bundle-Version: @VERSION_SHORT@
+Export-Package: tinyb
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 
 Name: tinyb/
-Specification-Title: TinyB
-Specification-Version: @VERSION_API@
-Specification-Vendor: Intel Corp.
 Package-Title: tinyb
-Package-Version: @VERSION_SHORT@
 Package-Vendor: Intel Corp.
-
+Package-Version: @VERSION_SHORT@
+Specification-Title: TinyB
+Specification-Vendor: Intel Corp.
+Specification-Version: @VERSION_API@


### PR DESCRIPTION
Added OSGI metadata to the manifest, so the library can be deployed in
OSGI environments. The headers where first generated with the bnd tool,
then manually copied inside the manifest template file with the
appropriate variable substitutions.
Also added a timestamp variable (BUILD_TSTAMP) in the main
CmakeLists.txt for use in the manifest file (and elsewhere, if needed).

Signed-off-by: Alan Alberghini <alan@iooota.com>