### PR TITLE
Downgrade required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1.0 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.0.0 FATAL_ERROR)
 project (tinyb)
 
 FIND_PACKAGE (Threads REQUIRED)


### PR DESCRIPTION
Downgraded minimum required cmake version to 3.0.0, in order for systems
shipping older cmake versions (namely, Raspbian 8) to build the
project.

Signed-off-by: Alan Alberghini <alan@iooota.com>