### PR TITLE
Fix JNI FindClass "tinyb/BluetoothNotification" not found

### DIFF
--- a/java/jni/BluetoothAdapter.cxx
+++ b/java/jni/BluetoothAdapter.cxx
@@ -286,7 +286,7 @@ void Java_tinyb_BluetoothAdapter_enablePoweredNotifications(JNIEnv *env, jobject
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_adapter->enable_powered_notifications([ callback_ptr ] (bool v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
@@ -376,7 +376,7 @@ void Java_tinyb_BluetoothAdapter_enableDiscoverableNotifications(JNIEnv *env, jo
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_adapter->enable_discoverable_notifications([ callback_ptr ] (bool v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
@@ -489,7 +489,7 @@ void Java_tinyb_BluetoothAdapter_enablePairableNotifications(JNIEnv *env, jobjec
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_adapter->enable_pairable_notifications([ callback_ptr ] (bool v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
@@ -622,7 +622,7 @@ void Java_tinyb_BluetoothAdapter_enableDiscoveringNotifications(JNIEnv *env, job
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_adapter->enable_discovering_notifications([ callback_ptr ] (bool v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);

--- a/java/jni/BluetoothDevice.cxx
+++ b/java/jni/BluetoothDevice.cxx
@@ -394,7 +394,7 @@ void Java_tinyb_BluetoothDevice_enablePairedNotifications(JNIEnv *env, jobject o
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_device->enable_paired_notifications([ callback_ptr ] (bool v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
@@ -484,7 +484,7 @@ void Java_tinyb_BluetoothDevice_enableTrustedNotifications(JNIEnv *env, jobject 
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_device->enable_trusted_notifications([ callback_ptr ] (bool v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
@@ -574,7 +574,7 @@ void Java_tinyb_BluetoothDevice_enableBlockedNotifications(JNIEnv *env, jobject 
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_device->enable_blocked_notifications([ callback_ptr ] (bool v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
@@ -664,7 +664,7 @@ void Java_tinyb_BluetoothDevice_enableRSSINotifications(JNIEnv *env, jobject obj
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_device->enable_rssi_notifications([ callback_ptr ] (int16_t v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 jclass short_cls = search_class(*jni_env, "java/lang/Short");
                 jmethodID constructor = search_method(*jni_env, short_cls, "<init>", "(S)V", false);
@@ -734,7 +734,7 @@ void Java_tinyb_BluetoothDevice_enableConnectedNotifications(JNIEnv *env, jobjec
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_device->enable_connected_notifications([ callback_ptr ] (bool v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);

--- a/java/jni/BluetoothGattCharacteristic.cxx
+++ b/java/jni/BluetoothGattCharacteristic.cxx
@@ -139,7 +139,7 @@ void Java_tinyb_BluetoothGattCharacteristic_enableValueNotifications(JNIEnv *env
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_gatt_char->enable_value_notifications([ callback_ptr ] (std::vector<unsigned char> &v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 unsigned int size = v.size();
 

--- a/java/jni/BluetoothGattDescriptor.cxx
+++ b/java/jni/BluetoothGattDescriptor.cxx
@@ -212,7 +212,7 @@ void Java_tinyb_BluetoothGattDescriptor_enableValueNotifications(JNIEnv *env, jo
         std::shared_ptr<JNIGlobalRef> callback_ptr(new JNIGlobalRef(callback));
         obj_gatt_desc->enable_value_notifications([ callback_ptr ] (std::vector<unsigned char> &v)
             {
-                jclass notification = search_class(*jni_env, JAVA_PACKAGE "/BluetoothNotification");
+                jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
                 unsigned int size = v.size();
 

--- a/java/jni/helper.cxx
+++ b/java/jni/helper.cxx
@@ -52,6 +52,17 @@ jclass search_class(JNIEnv *env, const char *clazz_name)
     return clazz;
 }
 
+jclass search_class(JNIEnv *env, jobject obj)
+{
+    jclass clazz = env->GetObjectClass(obj);
+    if (!clazz)
+    {
+        std::string error = "no class found: ";
+        throw std::runtime_error(error);
+    }
+    return clazz;
+}
+
 jmethodID search_method(JNIEnv *env, jclass clazz, const char *method_name,
                 const char *prototype, bool is_static)
 {

--- a/java/jni/helper.hpp
+++ b/java/jni/helper.hpp
@@ -32,6 +32,7 @@ jfieldID getInstanceField(JNIEnv *env, jobject obj);
 
 jclass search_class(JNIEnv *env, const char *clazz_name);
 jclass search_class(JNIEnv *env, tinyb::BluetoothObject &object);
+jclass search_class(JNIEnv *env, jobject obj);
 jmethodID search_method(JNIEnv *env, jclass clazz, const char *method_name,
                         const char *prototype, bool is_static);
 jfieldID search_field(JNIEnv *env, jclass clazz, const char *field_name,


### PR DESCRIPTION
- Issue #52 : JNI call to findClass BluetoothNotification failed

- This issue happen with javafx application,
but not with "simple" java application.
- This issue happen only with "tinyb/BluetoothNotification" interface.
- Using the callback reference to retrieve the class instead of using
FindClass works fine.

Signed-off-by: Julien Decaen <julien.decaen@activetainment.no>