### PR TITLE
Added getInterfaceName method

### DIFF
--- a/java/BluetoothAdapter.java
+++ b/java/BluetoothAdapter.java
@@ -230,6 +230,14 @@ public class BluetoothAdapter extends BluetoothObject
       * @return The local ID of the adapter.
       */
     public native String getModalias();
+    
+    /** Returns the interface name of the adapter.
+     * @return The interface name of the adapter.
+     */
+    public String getInterfaceName() {
+        String[] path = getObjectPath().split("/");
+        return path[path.length-1];
+    }
 
     private native void delete();
 


### PR DESCRIPTION
I added a simple method that retrieve the name of the bluetooth interface (i.e. hci0) in order to correctly identify the adapter.
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>