### PR TITLE
Force loading of tinyb lib

### DIFF
--- a/java/BluetoothManager.java
+++ b/java/BluetoothManager.java
@@ -34,6 +34,7 @@ public class BluetoothManager
 
     static {
         try {
+            System.loadLibrary("tinyb");
             System.loadLibrary("javatinyb");
         } catch (UnsatisfiedLinkError e) {
             System.err.println("Native code library failed to load.\n" + e);


### PR DESCRIPTION
I was trying to integrate TinyB in an OSGI framework, but I discovered that loading "javatinyb" is not sufficient because the framework doesn't load the dependencies. So, I explicitly added the loading of "tinyb" before of "javatinyb". This change doesn't break any compatibility and all the examples and applications continue to work as before, but I think that can be useful to avoid issues like this.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>