### PR TITLE
Fix java objects memory leak

### DIFF
--- a/java/jni/BluetoothAdapter.cxx
+++ b/java/jni/BluetoothAdapter.cxx
@@ -294,6 +294,7 @@ void Java_tinyb_BluetoothAdapter_enablePoweredNotifications(JNIEnv *env, jobject
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -384,6 +385,7 @@ void Java_tinyb_BluetoothAdapter_enableDiscoverableNotifications(JNIEnv *env, jo
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -497,6 +499,7 @@ void Java_tinyb_BluetoothAdapter_enablePairableNotifications(JNIEnv *env, jobjec
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -630,6 +633,7 @@ void Java_tinyb_BluetoothAdapter_enableDiscoveringNotifications(JNIEnv *env, job
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {

--- a/java/jni/BluetoothDevice.cxx
+++ b/java/jni/BluetoothDevice.cxx
@@ -402,6 +402,7 @@ void Java_tinyb_BluetoothDevice_enablePairedNotifications(JNIEnv *env, jobject o
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -492,6 +493,7 @@ void Java_tinyb_BluetoothDevice_enableTrustedNotifications(JNIEnv *env, jobject 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -582,6 +584,7 @@ void Java_tinyb_BluetoothDevice_enableBlockedNotifications(JNIEnv *env, jobject 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -672,6 +675,7 @@ void Java_tinyb_BluetoothDevice_enableRSSINotifications(JNIEnv *env, jobject obj
                 jobject result = jni_env->NewObject(short_cls, constructor, (jshort) v);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -742,6 +746,7 @@ void Java_tinyb_BluetoothDevice_enableConnectedNotifications(JNIEnv *env, jobjec
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -945,6 +950,7 @@ void Java_tinyb_BluetoothDevice_enableManufacturerDataNotifications(JNIEnv *env,
                 }
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -1055,6 +1061,7 @@ void Java_tinyb_BluetoothDevice_enableServiceDataNotifications(JNIEnv *env, jobj
                 }
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {
@@ -1147,6 +1154,7 @@ void Java_tinyb_BluetoothDevice_enableServicesResolvedNotifications(JNIEnv *env,
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {

--- a/java/jni/BluetoothGattCharacteristic.cxx
+++ b/java/jni/BluetoothGattCharacteristic.cxx
@@ -147,6 +147,7 @@ void Java_tinyb_BluetoothGattCharacteristic_enableValueNotifications(JNIEnv *env
                 jni_env->SetByteArrayRegion(result, 0, (jsize)size, (const jbyte *)&v[0]);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {

--- a/java/jni/BluetoothGattDescriptor.cxx
+++ b/java/jni/BluetoothGattDescriptor.cxx
@@ -220,6 +220,7 @@ void Java_tinyb_BluetoothGattDescriptor_enableValueNotifications(JNIEnv *env, jo
                 jni_env->SetByteArrayRegion(result, 0, (jsize)size, (const jbyte *)&v[0]);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
+                jni_env->DeleteLocalRef(result);
 
             });
     } catch (std::bad_alloc &e) {


### PR DESCRIPTION
Objects created by jni->NewObject inside callback code blocks
are not being released by the JVM as there is still a reference to the object.
Those object references are accumulated on the thread stack and
eventually occupy all the available space in the heap.

Deleting the LocalReference as soon as the object is no longer required allows
the GC to dispose those temporary objects