### PR TITLE
Fixed som typos and adding startNearbyDiscovery() methods (java code only)

### DIFF
--- a/api/tinyb/BluetoothAdapter.hpp
+++ b/api/tinyb/BluetoothAdapter.hpp
@@ -48,14 +48,6 @@ friend class tinyb::BluetoothNotificationHandler;
 private:
     Adapter1 *object;
 
-    /** Removes a device from the list of devices available on this adapter.
-      * @param[in] arg_device The path of the device on DBus
-      * @return TRUE if device was successfully removed
-      */
-    bool remove_device (
-        const std::string &arg_device
-    );
-
 protected:
     BluetoothAdapter(Adapter1 *object);
 
@@ -97,6 +89,14 @@ public:
 
     /* D-Bus method calls: */
 
+    /** Removes a device from the list of devices available on this adapter.
+      * @param[in] arg_device The path of the device on DBus
+      * @return TRUE if device was successfully removed
+      */
+    bool remove_device (
+        const std::string &arg_device
+    );
+    
     /** Turns on device discovery if it is disabled.
       * @return TRUE if discovery was successfully enabled
       */

--- a/java/BluetoothAdapter.java
+++ b/java/BluetoothAdapter.java
@@ -87,6 +87,14 @@ public class BluetoothAdapter extends BluetoothObject
       */
     public native List<BluetoothDevice> getDevices();
 
+    /**
+     * Remove all the known devices
+     * 
+     * @return The number of devices removed from internal list
+     * @throws BluetoothException 
+     */
+    public native int removeDevices() throws BluetoothException;
+    
     /* D-Bus property accessors: */
     /** Returns the hardware address of this adapter.
       * @return The hardware address of this adapter.

--- a/java/jni/BluetoothAdapter.cxx
+++ b/java/jni/BluetoothAdapter.cxx
@@ -134,6 +134,36 @@ jobject Java_tinyb_BluetoothAdapter_getDevices(JNIEnv *env, jobject obj)
     return nullptr;
 }
 
+jint Java_tinyb_BluetoothAdapter_removeDevices(JNIEnv *env, jobject obj)
+{
+    try {
+        BluetoothAdapter *obj_adapter = getInstance<BluetoothAdapter>(env, obj);
+        std::vector<std::unique_ptr<tinyb::BluetoothDevice>> array = obj_adapter->get_devices();
+        
+        for (unsigned int i =0;i<array.size();i++) {
+            std::unique_ptr<tinyb::BluetoothDevice> *obj_device = &array.at(i);
+            std::string path = obj_device->get()->get_object_path();
+            // printf("PATH:%s\n", path.c_str());
+            // fflush(stdout);
+            obj_adapter->remove_device(path.c_str());
+            
+        }
+        return array.size();
+        
+    } catch (std::bad_alloc &e) {
+        raise_java_oom_exception(env, e);
+    } catch (BluetoothException &e) {
+        raise_java_bluetooth_exception(env, e);
+    } catch (std::runtime_error &e) {
+        raise_java_runtime_exception(env, e);
+    } catch (std::invalid_argument &e) {
+        raise_java_invalid_arg_exception(env, e);
+    } catch (std::exception &e) {
+        raise_java_exception(env, e);
+    }
+    return 0;
+}
+
 jstring Java_tinyb_BluetoothAdapter_getAddress(JNIEnv *env, jobject obj)
 {
     try {

--- a/java/jni/BluetoothDevice.cxx
+++ b/java/jni/BluetoothDevice.cxx
@@ -34,7 +34,7 @@
 
 using namespace tinyb;
 
-jobject Java_tinyb_BluetoothAdapter_getBluetoothType(JNIEnv *env, jobject obj)
+jobject Java_tinyb_BluetoothDevice_getBluetoothType(JNIEnv *env, jobject obj)
 {
     try {
         (void)obj;
@@ -1098,7 +1098,7 @@ void Java_tinyb_BluetoothDevice_disableServiceDataNotifications(JNIEnv *env, job
 
 
 
-jshort Java_tinyb_BluetoothDevice_getTXPower(JNIEnv *env, jobject obj)
+jshort Java_tinyb_BluetoothDevice_getTxPower(JNIEnv *env, jobject obj)
 {
     try {
         BluetoothDevice *obj_device = getInstance<BluetoothDevice>(env, obj);

--- a/java/jni/helper.cxx
+++ b/java/jni/helper.cxx
@@ -188,7 +188,7 @@ jobject get_bluetooth_type(JNIEnv *env, const char *field_name)
 {
     jclass b_type_enum = search_class(env, JAVA_PACKAGE "/BluetoothType");
 
-    jfieldID b_type_field = search_field(env, b_type_enum, field_name, "l", true);
+    jfieldID b_type_field = search_field(env, b_type_enum, field_name, "L" JAVA_PACKAGE "/BluetoothType;", true);
 
     jobject result = env->GetStaticObjectField(b_type_enum, b_type_field);
     return result;


### PR DESCRIPTION
Fixed typo in BluetoothDevice.cxx, getTxPower() instead of getTXPower().

Fixed class name in helper.cxx get_bluetooth_type, "Ltinyb/BluetoothType"
instead of "l" 

Added a method removeDevices() in BluetoothAdapter class to remove all
the known devices (getDevices() will return an empty list after this call).

Added startNearbyDiscovery() and stopNearbyDiscovery() in BlutoothManager
main class. The start method will clear the internal device list and
send a notification to a listener when a new device is found.
The implementation is a simple thread which will poll each x miliseconds
the list of known devices and compare it to an internal list of known
devices, if the device is new, an event is fired to the passed listener.

Signed-off-by: sbodmer <sbodmer@lsi-media.ch>