### PR TITLE
Removed System.exit from BluetoothManager

### DIFF
--- a/java/BluetoothManager.java
+++ b/java/BluetoothManager.java
@@ -43,7 +43,6 @@ public class BluetoothManager
             System.loadLibrary("javatinyb");
         } catch (UnsatisfiedLinkError e) {
             System.err.println("Native code library failed to load.\n" + e);
-            System.exit(-1);
         }
     }
 
@@ -297,8 +296,6 @@ public class BluetoothManager
     {
         if (inst == null)
         {
-            inst = new BluetoothManager();
-            inst.init();
             String nativeAPIVersion = getNativeAPIVersion();
             String APIVersion = BluetoothManager.class.getPackage().getSpecificationVersion();
             if (APIVersion.equals(nativeAPIVersion) == false) {
@@ -318,6 +315,8 @@ public class BluetoothManager
                     System.err.println("Java library is out of date. Please update the Java library.");
                 else System.err.println("Native library is out of date. Please update the native library.");
             }
+            inst = new BluetoothManager();
+            inst.init();
         }
         return inst;
     }


### PR DESCRIPTION
The BluetoothManager.java has a static block that loads the native libs. If this fails, the application exits, killing the JVM. However, this can be problematic in some situation, like OSGI applications, where System.exit command kills the entire framework. It should be noted that, if the libs are not correctly loaded, an exception will be thrown in the getBluetoothManager method and this should be managed at application level.

In the getBluetoothManager method the creation of the BluetoothManager is moved after the checks about libraries version. In this way, if an error occurs, the object is not created.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>