### PR TITLE
drop dependencies of unused linked libraries

### DIFF
--- a/java/jni/CMakeLists.txt
+++ b/java/jni/CMakeLists.txt
@@ -19,6 +19,8 @@ include_directories(
 
 file(GLOB JNI_SOURCES "*.cxx")
 
+set (CMAKE_SHARED_LINKER_FLAGS "-Wl,--as-needed")
+
 add_library (javatinyb SHARED ${JNI_SOURCES})
 target_link_libraries(javatinyb ${JNI_LIBRARIES} tinyb)
 


### PR DESCRIPTION
`libjavatinyb.so` currently links against libraries that are not necessary
at runtime anymore.
For example the `libjawt.so` and `libjvm.so` needs to be found by the
dynamic linker at runtime without any need.

Here the output of `ldd` for `libjavatinyb.so` before:
```text
  linux-vdso.so.1 (0x00007ffed2fdf000)
  libjawt.so => not found
  libjvm.so => not found
  libtinyb.so.0.5.0-18-g6fb269f => /tmp/tinyb/build/install/lib64/libtinyb.so.0.5.0-18-g6fb269f (0x00007f68c50c6000)
  libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f68c4ea6000)
  libglib-2.0.so.0 => /usr/lib64/libglib-2.0.so.0 (0x00007f68c4b8f000)
  libgio-2.0.so.0 => /usr/lib64/libgio-2.0.so.0 (0x00007f68c47f9000)
  libgobject-2.0.so.0 => /usr/lib64/libgobject-2.0.so.0 (0x00007f68c45a5000)
  libstdc++.so.6 => /usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/libstdc++.so.6 (0x00007f68c41a3000)
  libm.so.6 => /lib64/libm.so.6 (0x00007f68c3e9a000)
  libgcc_s.so.1 => /usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/libgcc_s.so.1 (0x00007f68c3c83000)
  libc.so.6 => /lib64/libc.so.6 (0x00007f68c38d0000)
  /lib64/ld-linux-x86-64.so.2 (0x00005569851cc000)
  libpcre.so.1 => /lib64/libpcre.so.1 (0x00007f68c365f000)
  libgmodule-2.0.so.0 => /usr/lib64/libgmodule-2.0.so.0 (0x00007f68c345b000)
  libz.so.1 => /lib64/libz.so.1 (0x00007f68c3244000)
  libresolv.so.2 => /lib64/libresolv.so.2 (0x00007f68c302d000)
  libmount.so.1 => /lib64/libmount.so.1 (0x00007f68c2dd8000)
  libffi.so.6 => /usr/lib64/libffi.so.6 (0x00007f68c2bcd000)
  libdl.so.2 => /lib64/libdl.so.2 (0x00007f68c29c9000)
  libblkid.so.1 => /lib64/libblkid.so.1 (0x00007f68c277e000)
  librt.so.1 => /lib64/librt.so.1 (0x00007f68c2576000)
  libuuid.so.1 => /lib64/libuuid.so.1 (0x00007f68c2371000)
```

Here the output of `ldd` for `libjavatinyb.so` after:
```text
  linux-vdso.so.1 (0x00007fff037ce000)
  libtinyb.so.0.5.0-18-g6fb269f => /tmp/tinyb/build/install/lib64/libtinyb.so.0.5.0-18-g6fb269f (0x00007fd9f60d7000)
  libstdc++.so.6 => /usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/libstdc++.so.6 (0x00007fd9f5c99000)
  libgcc_s.so.1 => /usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/libgcc_s.so.1 (0x00007fd9f5a82000)
  libc.so.6 => /lib64/libc.so.6 (0x00007fd9f56d1000)
  /lib64/ld-linux-x86-64.so.2 (0x00005607dae4e000)
  libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fd9f54af000)
  libglib-2.0.so.0 => /usr/lib64/libglib-2.0.so.0 (0x00007fd9f519a000)
  libgio-2.0.so.0 => /usr/lib64/libgio-2.0.so.0 (0x00007fd9f4e04000)
  libgobject-2.0.so.0 => /usr/lib64/libgobject-2.0.so.0 (0x00007fd9f4bb0000)
  libm.so.6 => /lib64/libm.so.6 (0x00007fd9f48a7000)
  libpcre.so.1 => /lib64/libpcre.so.1 (0x00007fd9f4636000)
  libgmodule-2.0.so.0 => /usr/lib64/libgmodule-2.0.so.0 (0x00007fd9f4430000)
  libz.so.1 => /lib64/libz.so.1 (0x00007fd9f4219000)
  libresolv.so.2 => /lib64/libresolv.so.2 (0x00007fd9f4002000)
  libmount.so.1 => /lib64/libmount.so.1 (0x00007fd9f3dad000)
  libffi.so.6 => /usr/lib64/libffi.so.6 (0x00007fd9f3ba4000)
  libdl.so.2 => /lib64/libdl.so.2 (0x00007fd9f39a0000)
  libblkid.so.1 => /lib64/libblkid.so.1 (0x00007fd9f3753000)
  librt.so.1 => /lib64/librt.so.1 (0x00007fd9f354b000)
  libuuid.so.1 => /lib64/libuuid.so.1 (0x00007fd9f3346000)
```