### PR TITLE
Fix native memory leak

### DIFF
--- a/java/jni/BluetoothAdapter.cxx
+++ b/java/jni/BluetoothAdapter.cxx
@@ -318,8 +318,11 @@ void Java_tinyb_BluetoothAdapter_enablePoweredNotifications(JNIEnv *env, jobject
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
+                jni_env->DeleteLocalRef(boolean_cls);
 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
@@ -409,8 +412,11 @@ void Java_tinyb_BluetoothAdapter_enableDiscoverableNotifications(JNIEnv *env, jo
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
+                jni_env->DeleteLocalRef(boolean_cls);
 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
@@ -523,8 +529,11 @@ void Java_tinyb_BluetoothAdapter_enablePairableNotifications(JNIEnv *env, jobjec
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
+                jni_env->DeleteLocalRef(boolean_cls);
 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 
@@ -657,8 +666,11 @@ void Java_tinyb_BluetoothAdapter_enableDiscoveringNotifications(JNIEnv *env, job
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
+                jni_env->DeleteLocalRef(boolean_cls);
 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
 

--- a/java/jni/BluetoothDevice.cxx
+++ b/java/jni/BluetoothDevice.cxx
@@ -396,10 +396,13 @@ void Java_tinyb_BluetoothDevice_enablePairedNotifications(JNIEnv *env, jobject o
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
+                jni_env->DeleteLocalRef(boolean_cls);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
                 jni_env->DeleteLocalRef(result);
@@ -487,10 +490,13 @@ void Java_tinyb_BluetoothDevice_enableTrustedNotifications(JNIEnv *env, jobject 
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
+                jni_env->DeleteLocalRef(boolean_cls);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
                 jni_env->DeleteLocalRef(result);
@@ -578,10 +584,13 @@ void Java_tinyb_BluetoothDevice_enableBlockedNotifications(JNIEnv *env, jobject 
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
+                jni_env->DeleteLocalRef(boolean_cls);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
                 jni_env->DeleteLocalRef(result);
@@ -669,10 +678,13 @@ void Java_tinyb_BluetoothDevice_enableRSSINotifications(JNIEnv *env, jobject obj
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass short_cls = search_class(*jni_env, "java/lang/Short");
                 jmethodID constructor = search_method(*jni_env, short_cls, "<init>", "(S)V", false);
 
                 jobject result = jni_env->NewObject(short_cls, constructor, (jshort) v);
+                jni_env->DeleteLocalRef(short_cls);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
                 jni_env->DeleteLocalRef(result);
@@ -740,10 +752,13 @@ void Java_tinyb_BluetoothDevice_enableConnectedNotifications(JNIEnv *env, jobjec
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
+                jni_env->DeleteLocalRef(boolean_cls);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
                 jni_env->DeleteLocalRef(result);
@@ -925,6 +940,7 @@ void Java_tinyb_BluetoothDevice_enableManufacturerDataNotifications(JNIEnv *env,
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
 
                 jclass map_cls = search_class(*jni_env, "java/util/HashMap");
                 jmethodID map_ctor = search_method(*jni_env, map_cls, "<init>",
@@ -938,7 +954,7 @@ void Java_tinyb_BluetoothDevice_enableManufacturerDataNotifications(JNIEnv *env,
                                                     "(S)V", false);
 
                 jobject result = jni_env->NewObject(map_cls, map_ctor, v.size());
-
+                jni_env->DeleteLocalRef(map_cls);
                 for (auto it: v) {
                     jbyteArray arr = jni_env->NewByteArray(it.second.size());
                     jni_env->SetByteArrayRegion(arr, 0, it.second.size(), (const jbyte *)it.second.data());
@@ -951,6 +967,7 @@ void Java_tinyb_BluetoothDevice_enableManufacturerDataNotifications(JNIEnv *env,
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
                 jni_env->DeleteLocalRef(result);
+                jni_env->DeleteLocalRef(short_cls);
 
             });
     } catch (std::bad_alloc &e) {
@@ -1040,6 +1057,7 @@ void Java_tinyb_BluetoothDevice_enableServiceDataNotifications(JNIEnv *env, jobj
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
 
                 jclass map_cls = search_class(*jni_env, "java/util/HashMap");
                 jmethodID map_ctor = search_method(*jni_env, map_cls, "<init>",
@@ -1049,6 +1067,7 @@ void Java_tinyb_BluetoothDevice_enableServiceDataNotifications(JNIEnv *env, jobj
                                                    false);
 
                 jobject result = jni_env->NewObject(map_cls, map_ctor, v.size());
+                jni_env->DeleteLocalRef(map_cls);
 
                 for (auto it: v) {
                     jbyteArray arr = jni_env->NewByteArray(it.second.size());
@@ -1062,7 +1081,6 @@ void Java_tinyb_BluetoothDevice_enableServiceDataNotifications(JNIEnv *env, jobj
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
                 jni_env->DeleteLocalRef(result);
-
             });
     } catch (std::bad_alloc &e) {
         raise_java_oom_exception(env, e);
@@ -1148,10 +1166,13 @@ void Java_tinyb_BluetoothDevice_enableServicesResolvedNotifications(JNIEnv *env,
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
+
                 jclass boolean_cls = search_class(*jni_env, "java/lang/Boolean");
                 jmethodID constructor = search_method(*jni_env, boolean_cls, "<init>", "(Z)V", false);
 
                 jobject result = jni_env->NewObject(boolean_cls, constructor, v ? JNI_TRUE : JNI_FALSE);
+                jni_env->DeleteLocalRef(boolean_cls);
 
                 jni_env->CallVoidMethod(**callback_ptr, method, result);
                 jni_env->DeleteLocalRef(result);

--- a/java/jni/BluetoothGattCharacteristic.cxx
+++ b/java/jni/BluetoothGattCharacteristic.cxx
@@ -141,6 +141,7 @@ void Java_tinyb_BluetoothGattCharacteristic_enableValueNotifications(JNIEnv *env
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
                 unsigned int size = v.size();
 
                 jbyteArray result = jni_env->NewByteArray((jsize)size);

--- a/java/jni/BluetoothGattDescriptor.cxx
+++ b/java/jni/BluetoothGattDescriptor.cxx
@@ -214,6 +214,7 @@ void Java_tinyb_BluetoothGattDescriptor_enableValueNotifications(JNIEnv *env, jo
             {
                 jclass notification = search_class(*jni_env, **callback_ptr);
                 jmethodID  method = search_method(*jni_env, notification, "run", "(Ljava/lang/Object;)V", false);
+                jni_env->DeleteLocalRef(notification);
                 unsigned int size = v.size();
 
                 jbyteArray result = jni_env->NewByteArray((jsize)size);

--- a/java/jni/helper.cxx
+++ b/java/jni/helper.cxx
@@ -191,6 +191,7 @@ jobject get_bluetooth_type(JNIEnv *env, const char *field_name)
     jfieldID b_type_field = search_field(env, b_type_enum, field_name, "L" JAVA_PACKAGE "/BluetoothType;", true);
 
     jobject result = env->GetStaticObjectField(b_type_enum, b_type_field);
+    env->DeleteLocalRef(b_type_enum);
     return result;
 }
 
@@ -207,6 +208,7 @@ jobject get_new_arraylist(JNIEnv *env, unsigned int size, jmethodID *add)
 
     *add = search_method(env, arraylist_class, "add", "(Ljava/lang/Object;)Z", false);
 
+    env->DeleteLocalRef(arraylist_class);
     return result;
 }
 


### PR DESCRIPTION
jclass objects obtained in callback methods should be manually released
when no longer relevant

Signed-off-by: Tzafrir Poupko <tzafrir.poupko@earlysense.com>