### PR TITLE
Added Java method BluetoothDevice::remove()

### DIFF
--- a/api/tinyb/BluetoothDevice.hpp
+++ b/api/tinyb/BluetoothDevice.hpp
@@ -135,6 +135,12 @@ public:
       */
     bool pair (
     );
+	
+	/** Remove the current device (like an unpair).
+      * @return true if the device has been removed from the system.
+      */
+    bool remove_device(
+	);
 
     /** Cancels an initiated pairing operation
       * @return TRUE if the paring is cancelled successfully

--- a/java/BluetoothDevice.java
+++ b/java/BluetoothDevice.java
@@ -98,6 +98,12 @@ public class BluetoothDevice extends BluetoothObject
       * @return TRUE if the device connected and paired
       */
     public native boolean pair() throws BluetoothException;
+	
+	/** Remove this device from the system (like an unpair).
+	  * @return TRUE if the device has been removed
+      * @throws BluetoothException 
+      */
+     public native boolean remove() throws BluetoothException;
 
     /** Cancels an initiated pairing operation
       * @return TRUE if the paring is cancelled successfully

--- a/java/jni/BluetoothDevice.cxx
+++ b/java/jni/BluetoothDevice.cxx
@@ -176,6 +176,26 @@ jboolean Java_tinyb_BluetoothDevice_pair(JNIEnv *env, jobject obj)
     return JNI_FALSE;
 }
 
+jboolean Java_tinyb_BluetoothDevice_remove(JNIEnv *env, jobject obj)
+{
+    try {
+        BluetoothDevice *obj_device = getInstance<BluetoothDevice>(env, obj);
+
+        return obj_device->remove_device() ? JNI_TRUE : JNI_FALSE;
+    } catch (std::bad_alloc &e) {
+        raise_java_oom_exception(env, e);
+    } catch (BluetoothException &e) {
+        raise_java_bluetooth_exception(env, e);
+    } catch (std::runtime_error &e) {
+        raise_java_runtime_exception(env, e);
+    } catch (std::invalid_argument &e) {
+        raise_java_invalid_arg_exception(env, e);
+    } catch (std::exception &e) {
+        raise_java_exception(env, e);
+    }
+    return JNI_FALSE;
+}
+
 jboolean Java_tinyb_BluetoothDevice_cancelPairing(JNIEnv *env, jobject obj)
 {
     try {

--- a/src/BluetoothDevice.cpp
+++ b/src/BluetoothDevice.cpp
@@ -298,6 +298,12 @@ bool BluetoothDevice::pair ()
     return result;
 }
 
+// Remove the device (like an unpair)
+bool BluetoothDevice::remove_device(){
+    BluetoothAdapter ba = get_adapter();
+    return ba.remove_device(get_object_path());
+}
+
 bool BluetoothDevice::cancel_pairing ()
 {
     GError *error = NULL;


### PR DESCRIPTION
Now it's possible to remove a single device calling directly the method "remove" from Java.

Signed-off-by: Jorge Esteves <jorge.esteves@supsi.ch>