### PR TITLE
Removing System.exit as it causes to exit application containers

### DIFF
--- a/java/BluetoothObject.java
+++ b/java/BluetoothObject.java
@@ -36,7 +36,6 @@ public abstract class BluetoothObject implements Cloneable,AutoCloseable
             System.loadLibrary("javatinyb");
         } catch (UnsatisfiedLinkError e) {
             System.err.println("Native code library failed to load.\n" + e);
-            System.exit(-1);
         }
     }
 


### PR DESCRIPTION
Further to https://github.com/intel-iot-devkit/tinyb/pull/116 another System.exit is removed to prevent application containers (e.g. OSGi and Spring) to exit. The reason why it is important is that tinyb native libraries could be "side-loaded" through creating a temporary file etc.

Signed-off-by: Vlad Kolotov <vkolotov@gmail.com>