### PR TITLE
Added Java method BluetoothManager::getDiscovering()

### DIFF
--- a/api/tinyb/BluetoothManager.hpp
+++ b/api/tinyb/BluetoothManager.hpp
@@ -238,4 +238,10 @@ public:
       */
     bool stop_discovery(
     );
+
+    /** Returns if the discovers is running or not.
+      * @return TRUE if discovery is running
+      */
+    bool get_discovering(
+    );
 };

--- a/java/BluetoothManager.java
+++ b/java/BluetoothManager.java
@@ -205,6 +205,11 @@ public class BluetoothManager
       */
     public native boolean stopDiscovery() throws BluetoothException;
 
+    /** Returns if the discovers is running or not.
+      * @return TRUE if discovery is running
+      */
+    public native boolean getDiscovering() throws BluetoothException;  
+
     /**
      * When called, each new device found will fire an event to the passed
      * listener<p>

--- a/java/jni/BluetoothManager.cxx
+++ b/java/jni/BluetoothManager.cxx
@@ -370,6 +370,25 @@ jboolean Java_tinyb_BluetoothManager_stopDiscovery(JNIEnv *env, jobject obj)
     return JNI_FALSE;
 }
 
+jboolean Java_tinyb_BluetoothManager_getDiscovering(JNIEnv *env, jobject obj)
+{
+    try {
+        BluetoothManager *manager = getInstance<BluetoothManager>(env, obj);
+        return manager->get_discovering() ? JNI_TRUE : JNI_FALSE;
+    } catch (std::bad_alloc &e) {
+        raise_java_oom_exception(env, e);
+    } catch (BluetoothException &e) {
+        raise_java_bluetooth_exception(env, e);
+    } catch (std::runtime_error &e) {
+        raise_java_runtime_exception(env, e);
+    } catch (std::invalid_argument &e) {
+        raise_java_invalid_arg_exception(env, e);
+    } catch (std::exception &e) {
+        raise_java_exception(env, e);
+    }
+    return JNI_FALSE;
+}
+
 void Java_tinyb_BluetoothManager_init(JNIEnv *env, jobject obj)
 {
     try {

--- a/src/BluetoothManager.cpp
+++ b/src/BluetoothManager.cpp
@@ -391,3 +391,11 @@ bool BluetoothManager::stop_discovery()
     else
         return false;
 }
+
+bool BluetoothManager::get_discovering()
+{
+    if (default_adapter != NULL)
+        return default_adapter->get_discovering();
+    else
+        return false;
+}


### PR DESCRIPTION
Added a method to check if a discovery process is running directly from the BluetoothManager (completion to startDiscovery and stopDiscovery).

Signed-off-by: Jorge Esteves <jorge.esteves@supsi.ch>