### PR TITLE
Adding support for setting discovery filters

### DIFF
--- a/api/tinyb/BluetoothAdapter.hpp
+++ b/api/tinyb/BluetoothAdapter.hpp
@@ -34,12 +34,6 @@ typedef struct _Object Object;
 struct _Adapter1;
 typedef struct _Adapter1 Adapter1;
 
-enum class TransportType {
-    AUTO,
-    BREDR,
-    LE
-};
-
 /**
   * Provides access to Bluetooth adapters. Follows the BlueZ adapter API
   * available at: http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/adapter-api.txt

--- a/api/tinyb/BluetoothAdapter.hpp
+++ b/api/tinyb/BluetoothAdapter.hpp
@@ -25,6 +25,7 @@
 #pragma once
 #include "BluetoothObject.hpp"
 #include "BluetoothManager.hpp"
+#include "BluetoothUUID.hpp"
 #include <vector>
 
 /* Forward declaration of types */
@@ -32,6 +33,12 @@ struct _Object;
 typedef struct _Object Object;
 struct _Adapter1;
 typedef struct _Adapter1 Adapter1;
+
+enum class TransportType {
+    AUTO,
+    BREDR,
+    LE
+};
 
 /**
   * Provides access to Bluetooth adapters. Follows the BlueZ adapter API
@@ -109,6 +116,15 @@ public:
     bool stop_discovery (
     );
 
+    /** Sets the device discovery filter for the caller. If all fields are empty,
+      * filter is removed.
+      * @param uuids Vector of UUIDs to filter on
+      * @param rssi RSSI low bounded threshold
+      * @param pathloss Pathloss threshold value
+      * @param transport Type of scan to run
+      */
+    bool set_discovery_filter (std::vector<BluetoothUUID> uuids,
+    int16_t rssi, uint16_t pathloss, const TransportType &transport);
 
     /** Returns a list of BluetoothDevices visible from this adapter.
       * @return A list of BluetoothDevices visible on this adapter,

--- a/api/tinyb/BluetoothObject.hpp
+++ b/api/tinyb/BluetoothObject.hpp
@@ -38,6 +38,11 @@ enum class BluetoothType {
     GATT_CHARACTERISTIC,
     GATT_DESCRIPTOR
 };
+    enum class TransportType {
+        AUTO,
+        BREDR,
+        LE
+    };
 
     class BluetoothEvent;
     class BluetoothEventManager;

--- a/include/generated-code.h
+++ b/include/generated-code.h
@@ -42,6 +42,11 @@ struct _Adapter1Iface
     Adapter1 *object,
     GDBusMethodInvocation *invocation);
 
+  gboolean (*handle_set_discovery_filter) (
+    Adapter1 *object,
+    GDBusMethodInvocation *invocation,
+    GVariant *arg_filter);
+
   const gchar * (*get_address) (Adapter1 *object);
 
   const gchar * (*get_alias) (Adapter1 *object);
@@ -140,6 +145,23 @@ gboolean adapter1_call_remove_device_sync (
     GCancellable *cancellable,
     GError **error);
 
+void adapter1_call_set_discovery_filter (
+        Adapter1 *proxy,
+        GVariant *arg_filter,
+        GCancellable *cancellable,
+        GAsyncReadyCallback callback,
+        gpointer user_data);
+
+gboolean adapter1_call_set_discovery_filter_finish (
+        Adapter1 *proxy,
+        GAsyncResult *res,
+        GError **error);
+
+gboolean adapter1_call_set_discovery_filter_sync (
+        Adapter1 *proxy,
+        GVariant *arg_filter,
+        GCancellable *cancellable,
+        GError **error);
 
 
 /* D-Bus property accessors: */

--- a/java/BluetoothAdapter.java
+++ b/java/BluetoothAdapter.java
@@ -258,8 +258,12 @@ public class BluetoothAdapter extends BluetoothObject
      * @param rssi a rssi value
      * @param pathloss a pathloss value
      */
-    public void setDiscoveryFilter(List<Integer> uuids, int rssi, int pathloss, TransportType transportType) {
-        setDiscoveryFilter(uuids, rssi, pathloss, transportType.ordinal());
+    public void setDiscoveryFilter(List<UUID> uuids, int rssi, int pathloss, TransportType transportType) {
+        List<String> uuidsFmt = new ArrayList<>(uuids.size());
+        for (UUID uuid : uuids) {
+            uuidsFmt.add(uuid.toString());
+        }
+        setDiscoveryFilter(uuidsFmt, rssi, pathloss, transportType.ordinal());
     }
 
     /** This method sets RSSI device discovery filter for the caller. When this method is called
@@ -280,7 +284,7 @@ public class BluetoothAdapter extends BluetoothObject
 
     private native void delete();
 
-    private native void setDiscoveryFilter(List<Integer> uuids, int rssi, int pathloss, int transportType);
+    private native void setDiscoveryFilter(List<String> uuids, int rssi, int pathloss, int transportType);
 
     private BluetoothAdapter(long instance)
     {

--- a/java/BluetoothAdapter.java
+++ b/java/BluetoothAdapter.java
@@ -238,7 +238,13 @@ public class BluetoothAdapter extends BluetoothObject
       * @return The local ID of the adapter.
       */
     public native String getModalias();
-    
+
+    /** This method sets RSSI device discovery filter for the caller. When this method is called
+      * with 0, filter is removed.
+      * @param rssi a rssi value
+      */
+    public native void setRssiDiscoveryFilter(int rssi);
+
     /** Returns the interface name of the adapter.
      * @return The interface name of the adapter.
      */

--- a/java/BluetoothAdapter.java
+++ b/java/BluetoothAdapter.java
@@ -239,11 +239,36 @@ public class BluetoothAdapter extends BluetoothObject
       */
     public native String getModalias();
 
+    /** This method sets the device discovery filter for the caller. When this method is called
+     * with no filter parameter, filter is removed.
+     * <p>
+     * When a remote device is found that advertises any UUID from UUIDs, it will be reported if:
+     * <ul><li>Pathloss and RSSI are both empty.</li>
+     * <li>only Pathloss param is set, device advertise TX pwer, and computed pathloss is less than Pathloss param.</li>
+     * <li>only RSSI param is set, and received RSSI is higher than RSSI param.</li>
+     * </ul>
+     * <p>
+     * If one or more discovery filters have been set, the RSSI delta-threshold,
+     * that is imposed by StartDiscovery by default, will not be applied.
+     * <p>
+     * If "auto" transport is requested, scan will use LE, BREDR, or both, depending on what's
+     * currently enabled on the controller.
+     *
+     * @param uuids a list of device UUIDs
+     * @param rssi a rssi value
+     * @param pathloss a pathloss value
+     */
+    public void setDiscoveryFilter(List<Integer> uuids, int rssi, int pathloss, TransportType transportType) {
+        setDiscoveryFilter(uuids, rssi, pathloss, transportType.ordinal());
+    }
+
     /** This method sets RSSI device discovery filter for the caller. When this method is called
       * with 0, filter is removed.
       * @param rssi a rssi value
       */
-    public native void setRssiDiscoveryFilter(int rssi);
+    public void setRssiDiscoveryFilter(int rssi) {
+        setDiscoveryFilter(Collections.EMPTY_LIST, rssi, 0, TransportType.AUTO);
+    }
 
     /** Returns the interface name of the adapter.
      * @return The interface name of the adapter.
@@ -254,6 +279,8 @@ public class BluetoothAdapter extends BluetoothObject
     }
 
     private native void delete();
+
+    private native void setDiscoveryFilter(List<Integer> uuids, int rssi, int pathloss, int transportType);
 
     private BluetoothAdapter(long instance)
     {

--- a/java/TransportType.java
+++ b/java/TransportType.java
@@ -1,0 +1,19 @@
+package tinyb;
+
+/**
+ * TransportType determines type of bluetooth scan.
+ */
+public enum TransportType {
+    /**
+     * interleaved scan
+     */
+    AUTO,
+    /**
+     * BR/EDR inquiry
+     */
+    BREDR,
+    /**
+     * LE scan only
+     */
+    LE
+}

--- a/java/jni/BluetoothAdapter.cxx
+++ b/java/jni/BluetoothAdapter.cxx
@@ -787,3 +787,24 @@ void Java_tinyb_BluetoothAdapter_delete(JNIEnv *env, jobject obj)
     }
 }
 
+void Java_tinyb_BluetoothAdapter_setRssiDiscoveryFilter(JNIEnv *env, jobject obj, jint rssi)
+{
+    try {
+        BluetoothAdapter *obj_adapter = getInstance<BluetoothAdapter>(env, obj);
+
+        std::vector<BluetoothUUID> native_uuids;
+        native_uuids.reserve(0);
+
+        obj_adapter->set_discovery_filter(native_uuids, (int16_t) rssi, 0, TransportType::AUTO);
+    } catch (std::bad_alloc &e) {
+        raise_java_oom_exception(env, e);
+    } catch (BluetoothException &e) {
+        raise_java_bluetooth_exception(env, e);
+    } catch (std::runtime_error &e) {
+        raise_java_runtime_exception(env, e);
+    } catch (std::invalid_argument &e) {
+        raise_java_invalid_arg_exception(env, e);
+    } catch (std::exception &e) {
+        raise_java_exception(env, e);
+    }
+}

--- a/java/jni/BluetoothAdapter.cxx
+++ b/java/jni/BluetoothAdapter.cxx
@@ -792,8 +792,21 @@ void Java_tinyb_BluetoothAdapter_setDiscoveryFilter(JNIEnv *env, jobject obj, jo
     try {
         BluetoothAdapter *obj_adapter = getInstance<BluetoothAdapter>(env, obj);
 
+        jclass cList = env->FindClass("java/util/List");
+
+        jmethodID mSize = env->GetMethodID(cList, "size", "()I");
+        jmethodID mGet = env->GetMethodID(cList, "get", "(I)Ljava/lang/Object;");
+
+        jint size = env->CallIntMethod(uuids, mSize);
         std::vector<BluetoothUUID> native_uuids;
-        native_uuids.reserve(0);
+
+        for (jint i = 0; i < size; i++) {
+            jstring strObj = (jstring) env->CallObjectMethod(uuids, mGet, i);
+            const char * chr = env->GetStringUTFChars(strObj, NULL);
+            BluetoothUUID uuid(chr);
+            native_uuids.push_back(uuid);
+            env->ReleaseStringUTFChars(strObj, chr);
+        }
 
         TransportType t_type = from_int_to_transport_type((int) transportType);
 

--- a/java/jni/BluetoothAdapter.cxx
+++ b/java/jni/BluetoothAdapter.cxx
@@ -787,7 +787,7 @@ void Java_tinyb_BluetoothAdapter_delete(JNIEnv *env, jobject obj)
     }
 }
 
-void Java_tinyb_BluetoothAdapter_setRssiDiscoveryFilter(JNIEnv *env, jobject obj, jint rssi)
+void Java_tinyb_BluetoothAdapter_setDiscoveryFilter(JNIEnv *env, jobject obj, jobject uuids, jint rssi, jint pathloss, jint transportType)
 {
     try {
         BluetoothAdapter *obj_adapter = getInstance<BluetoothAdapter>(env, obj);
@@ -795,8 +795,10 @@ void Java_tinyb_BluetoothAdapter_setRssiDiscoveryFilter(JNIEnv *env, jobject obj
         std::vector<BluetoothUUID> native_uuids;
         native_uuids.reserve(0);
 
-        obj_adapter->set_discovery_filter(native_uuids, (int16_t) rssi, 0, TransportType::AUTO);
-    } catch (std::bad_alloc &e) {
+        TransportType t_type = from_int_to_transport_type((int) transportType);
+
+        obj_adapter->set_discovery_filter(native_uuids, (int16_t) rssi, (uint16_t) pathloss, t_type);
+    } catch (std::bad_alloc &e)     {
         raise_java_oom_exception(env, e);
     } catch (BluetoothException &e) {
         raise_java_bluetooth_exception(env, e);

--- a/java/jni/helper.cxx
+++ b/java/jni/helper.cxx
@@ -183,6 +183,31 @@ tinyb::BluetoothType from_int_to_btype(int type)
     return result;
 }
 
+tinyb::TransportType from_int_to_transport_type(int type)
+{
+    tinyb::TransportType result = tinyb::TransportType::AUTO;
+
+    switch (type)
+    {
+        case 0:
+            result = tinyb::TransportType::AUTO;
+            break;
+
+        case 1:
+            result = tinyb::TransportType::BREDR;
+            break;
+
+        case 2:
+            result = tinyb::TransportType::LE;
+            break;
+
+        default:
+            result = tinyb::TransportType::AUTO;
+            break;
+    }
+
+    return result;
+}
 
 jobject get_bluetooth_type(JNIEnv *env, const char *field_name)
 {

--- a/java/jni/helper.hpp
+++ b/java/jni/helper.hpp
@@ -42,6 +42,7 @@ std::string from_jstring_to_string(JNIEnv *env, jstring str);
 tinyb::BluetoothType from_int_to_btype(int type);
 jobject get_bluetooth_type(JNIEnv *env, const char *field_name);
 jobject get_new_arraylist(JNIEnv *env, unsigned int size, jmethodID *add);
+tinyb::TransportType from_int_to_transport_type(int type);
 
 template <typename T>
 T *getInstance(JNIEnv *env, jobject obj)

--- a/src/BluetoothAdapter.cpp
+++ b/src/BluetoothAdapter.cpp
@@ -221,12 +221,12 @@ bool BluetoothAdapter::set_discovery_filter (std::vector<BluetoothUUID> uuids,
 
     if (uuids.size() > 0)
     {
-        GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE("a(s)"));
+        GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE("as"));
 
         for (std::vector<BluetoothUUID>::iterator i = uuids.begin(); i != uuids.end(); ++i)
-            g_variant_builder_add(builder, "(s)", (*i).get_string().c_str());
+            g_variant_builder_add(builder, "s", (*i).get_string().c_str());
 
-        GVariant *uuids_variant = g_variant_new("a(s)", builder);
+        GVariant *uuids_variant = g_variant_new("as", builder);
         g_variant_builder_unref(builder);
         g_variant_dict_insert_value(&dict, "UUIDs", uuids_variant);
     }

--- a/src/BluetoothAdapter.cpp
+++ b/src/BluetoothAdapter.cpp
@@ -211,6 +211,57 @@ bool BluetoothAdapter::remove_device (
     return result;
 }
 
+bool BluetoothAdapter::set_discovery_filter (std::vector<BluetoothUUID> uuids,
+    int16_t rssi, uint16_t pathloss, const TransportType &transport)
+{
+    GError *error = NULL;
+    bool result = true;
+    GVariantDict dict;
+    g_variant_dict_init(&dict, NULL);
+
+    if (uuids.size() > 0)
+    {
+        GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE("a(s)"));
+
+        for (std::vector<BluetoothUUID>::iterator i = uuids.begin(); i != uuids.end(); ++i)
+            g_variant_builder_add(builder, "(s)", (*i).get_string().c_str());
+
+        GVariant *uuids_variant = g_variant_new("a(s)", builder);
+        g_variant_builder_unref(builder);
+        g_variant_dict_insert_value(&dict, "UUIDs", uuids_variant);
+    }
+
+    if (rssi != 0)
+        g_variant_dict_insert_value(&dict, "RSSI", g_variant_new_int16(rssi));
+
+    if (pathloss != 0)
+        g_variant_dict_insert_value(&dict, "Pathloss", g_variant_new_uint16(pathloss));
+
+    std::string transport_str;
+
+    if (transport == TransportType::AUTO)
+        transport_str = "auto";
+    else if (transport == TransportType::BREDR)
+        transport_str = "bredr";
+    else if (transport == TransportType::LE)
+        transport_str = "le";
+
+    if (!transport_str.empty())
+        g_variant_dict_insert_value(&dict, "Transport", g_variant_new_string(transport_str.c_str()));
+
+    GVariant *variant = g_variant_dict_end(&dict);
+
+    result = adapter1_call_set_discovery_filter_sync(
+        object,
+        variant,
+        NULL,
+        &error
+    );
+
+    handle_error(error);
+    return result;
+}
+
 /* D-Bus property accessors: */
 std::string BluetoothAdapter::get_address ()
 {

--- a/src/generated-code.c
+++ b/src/generated-code.c
@@ -219,11 +219,42 @@ static const _ExtendedGDBusMethodInfo _adapter1_method_info_remove_device =
   FALSE
 };
 
+static const _ExtendedGDBusArgInfo _adapter1_method_info_set_discovery_filter_IN_ARG_filter =
+{
+  {
+    -1,
+    (gchar *) "filter",
+    (gchar *) "a{sv}",
+    NULL
+  },
+  FALSE
+};
+
+static const _ExtendedGDBusArgInfo * const _adapter1_method_info_set_discovery_filter_IN_ARG_pointers[] =
+{
+  &_adapter1_method_info_set_discovery_filter_IN_ARG_filter,
+  NULL
+};
+
+static const _ExtendedGDBusMethodInfo _adapter1_method_info_set_discovery_filter =
+{
+  {
+    -1,
+    (gchar *) "SetDiscoveryFilter",
+    (GDBusArgInfo **) &_adapter1_method_info_set_discovery_filter_IN_ARG_pointers,
+    NULL,
+    NULL
+  },
+  "handle-set-discovery-filter",
+  FALSE
+};
+
 static const _ExtendedGDBusMethodInfo * const _adapter1_method_info_pointers[] =
 {
   &_adapter1_method_info_start_discovery,
   &_adapter1_method_info_stop_discovery,
   &_adapter1_method_info_remove_device,
+  &_adapter1_method_info_set_discovery_filter,
   NULL
 };
 
@@ -467,6 +498,7 @@ adapter1_override_properties (GObjectClass *klass, guint property_id_begin)
  * Adapter1Iface:
  * @parent_iface: The parent interface.
  * @handle_remove_device: Handler for the #Adapter1::handle-remove-device signal.
+ * @handle_set_discovery_filter: Handler for the #Adapter1::handle-set-discovery-filter signal.
  * @handle_start_discovery: Handler for the #Adapter1::handle-start-discovery signal.
  * @handle_stop_discovery: Handler for the #Adapter1::handle-stop-discovery signal.
  * @get_address: Getter for the #Adapter1:address property.
@@ -558,6 +590,29 @@ adapter1_default_init (Adapter1Iface *iface)
     G_TYPE_BOOLEAN,
     2,
     G_TYPE_DBUS_METHOD_INVOCATION, G_TYPE_STRING);
+
+  /**
+   * Adapter1::handle-set-discovery-filter:
+   * @object: A #Adapter1.
+   * @invocation: A #GDBusMethodInvocation.
+   * @arg_filter: Argument passed by remote caller.
+   *
+   * Signal emitted when a remote caller is invoking the <link linkend="gdbus-method-org-bluez-Adapter1.SetDiscoveryFilter">SetDiscoveryFilter()</link> D-Bus method.
+   *
+   * If a signal handler returns %TRUE, it means the signal handler will handle the invocation (e.g. take a reference to @invocation and eventually call adapter1_complete_set_discovery_filter() or e.g. g_dbus_method_invocation_return_error() on it) and no order signal handlers will run. If no signal handler handles the invocation, the %G_DBUS_ERROR_UNKNOWN_METHOD error is returned.
+   *
+   * Returns: %TRUE if the invocation was handled, %FALSE to let other signal handlers run.
+   */
+  g_signal_new ("handle-set-discovery-filter",
+    G_TYPE_FROM_INTERFACE (iface),
+    G_SIGNAL_RUN_LAST,
+    G_STRUCT_OFFSET (Adapter1Iface, handle_set_discovery_filter),
+    g_signal_accumulator_true_handled,
+    NULL,
+    g_cclosure_marshal_generic,
+    G_TYPE_BOOLEAN,
+    2,
+    G_TYPE_DBUS_METHOD_INVOCATION, G_TYPE_VARIANT);
 
   /* GObject properties for D-Bus properties: */
   /**
@@ -1425,6 +1480,104 @@ _out:
 }
 
 /**
+ * adapter1_call_set_discovery_filter:
+ * @proxy: A #Adapter1Proxy.
+ * @arg_filter: Argument to pass with the method invocation.
+ * @cancellable: (allow-none): A #GCancellable or %NULL.
+ * @callback: A #GAsyncReadyCallback to call when the request is satisfied or %NULL.
+ * @user_data: User data to pass to @callback.
+ *
+ * Asynchronously invokes the <link linkend="gdbus-method-org-bluez-Adapter1.SetDiscoveryFilter">SetDiscoveryFilter()</link> D-Bus method on @proxy.
+ * When the operation is finished, @callback will be invoked in the <link linkend="g-main-context-push-thread-default">thread-default main loop</link> of the thread you are calling this method from.
+ * You can then call adapter1_call_set_discovery_filter_finish() to get the result of the operation.
+ *
+ * See adapter1_call_set_discovery_filter_sync() for the synchronous, blocking version of this method.
+ */
+void
+adapter1_call_set_discovery_filter (
+    Adapter1 *proxy,
+    GVariant *arg_filter,
+    GCancellable *cancellable,
+    GAsyncReadyCallback callback,
+    gpointer user_data)
+{
+  g_dbus_proxy_call (G_DBUS_PROXY (proxy),
+    "SetDiscoveryFilter",
+    g_variant_new ("(@a{sv})",
+                   arg_filter),
+    G_DBUS_CALL_FLAGS_NONE,
+    -1,
+    cancellable,
+    callback,
+    user_data);
+}
+
+/**
+ * adapter1_call_set_discovery_filter_finish:
+ * @proxy: A #Adapter1Proxy.
+ * @res: The #GAsyncResult obtained from the #GAsyncReadyCallback passed to adapter1_call_set_discovery_filter().
+ * @error: Return location for error or %NULL.
+ *
+ * Finishes an operation started with adapter1_call_set_discovery_filter().
+ *
+ * Returns: (skip): %TRUE if the call succeded, %FALSE if @error is set.
+ */
+gboolean
+adapter1_call_set_discovery_filter_finish (
+    Adapter1 *proxy,
+    GAsyncResult *res,
+    GError **error)
+{
+  GVariant *_ret;
+  _ret = g_dbus_proxy_call_finish (G_DBUS_PROXY (proxy), res, error);
+  if (_ret == NULL)
+    goto _out;
+  g_variant_get (_ret,
+                 "()");
+  g_variant_unref (_ret);
+_out:
+  return _ret != NULL;
+}
+
+/**
+ * adapter1_call_set_discovery_filter_sync:
+ * @proxy: A #Adapter1Proxy.
+ * @arg_filter: Argument to pass with the method invocation.
+ * @cancellable: (allow-none): A #GCancellable or %NULL.
+ * @error: Return location for error or %NULL.
+ *
+ * Synchronously invokes the <link linkend="gdbus-method-org-bluez-Adapter1.SetDiscoveryFilter">SetDiscoveryFilter()</link> D-Bus method on @proxy. The calling thread is blocked until a reply is received.
+ *
+ * See adapter1_call_set_discovery_filter() for the asynchronous version of this method.
+ *
+ * Returns: (skip): %TRUE if the call succeded, %FALSE if @error is set.
+ */
+gboolean
+adapter1_call_set_discovery_filter_sync (
+    Adapter1 *proxy,
+    GVariant *arg_filter,
+    GCancellable *cancellable,
+    GError **error)
+{
+  GVariant *_ret;
+  _ret = g_dbus_proxy_call_sync (G_DBUS_PROXY (proxy),
+    "SetDiscoveryFilter",
+    g_variant_new ("(@a{sv})",
+                   arg_filter),
+    G_DBUS_CALL_FLAGS_NONE,
+    -1,
+    cancellable,
+    error);
+  if (_ret == NULL)
+    goto _out;
+  g_variant_get (_ret,
+                 "()");
+  g_variant_unref (_ret);
+_out:
+  return _ret != NULL;
+}
+
+/**
  * adapter1_complete_start_discovery:
  * @object: A #Adapter1.
  * @invocation: (transfer full): A #GDBusMethodInvocation.
@@ -1471,6 +1624,24 @@ adapter1_complete_stop_discovery (
  */
 void
 adapter1_complete_remove_device (
+    Adapter1 *object,
+    GDBusMethodInvocation *invocation)
+{
+  g_dbus_method_invocation_return_value (invocation,
+    g_variant_new ("()"));
+}
+
+/**
+ * adapter1_complete_set_discovery_filter:
+ * @object: A #Adapter1.
+ * @invocation: (transfer full): A #GDBusMethodInvocation.
+ *
+ * Helper function used in service implementations to finish handling invocations of the <link linkend="gdbus-method-org-bluez-Adapter1.SetDiscoveryFilter">SetDiscoveryFilter()</link> D-Bus method. If you instead want to finish handling an invocation by returning an error, use g_dbus_method_invocation_return_error() or similar.
+ *
+ * This method will free @invocation, you cannot use it afterwards.
+ */
+void
+adapter1_complete_set_discovery_filter (
     Adapter1 *object,
     GDBusMethodInvocation *invocation)
 {

--- a/src/org.bluez.xml
+++ b/src/org.bluez.xml
@@ -28,6 +28,9 @@ THE SOFTWARE.
     <method name="RemoveDevice">
       <arg name="device" type="o" direction="in"/>
     </method>
+    <method name="SetDiscoveryFilter">
+      <arg name="filter" type="a{sv}" direction="in"/>
+    </method>
     <property name="Address" type="s" access="read"/>
     <property name="Name" type="s" access="read"/>
     <property name="Alias" type="s" access="readwrite"/>


### PR DESCRIPTION
This PR is to merge @impala454's work (https://github.com/impala454/tinyb) to add support for setting discovery filters and to close https://github.com/intel-iot-devkit/tinyb/issues/80 issue.

I'm not a big expert in c++, it was a bit hard for me to properly merge you stuff @impala454 for dbus-codegen (https://github.com/intel-iot-devkit/tinyb/issues/101). I just only copied what I needed to implement setting discovery filters.

@petreeftime could you please review my changes and merge to the upstream?

PS. I have not tested c++ code directly, but I did some tests for java, this probably mean that c++ part works as well.

Signed-off-by: Vlad Kolotov <vkolotov@gmail.com>