### PR TITLE
JNIMem: Do not detach Java threads to avoid segfault when JVM terminates

### DIFF
--- a/java/jni/JNIMem.hpp
+++ b/java/jni/JNIMem.hpp
@@ -36,6 +36,7 @@ extern JavaVM* vm;
 class JNIEnvContainer {
 private:    
     JNIEnv *env = nullptr;
+    bool shouldDetach = false;
     
 public:
     /* Attaches this thread to the JVM if it is not already attached */


### PR DESCRIPTION
Resolves #135

Signed-off-by: Paolo Fisico <pgfisico.dev@gmail.com>