### PR TITLE
Fixed missing javah in openJDK 10+

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,6 +1,10 @@
 find_package(Java REQUIRED)
 include(UseJava)
 
+set(JAVA_AWT_INCLUDE_PATH NotNeeded)
+
+
+
 if (NOT DEFINED $ENV{JAVA_HOME_NATIVE})
   set (JAVA_HOME_NATIVE $ENV{JAVA_HOME})
   set (JAVAC $ENV{JAVA_HOME}/bin/javac)
@@ -12,9 +16,9 @@ endif ()
 
 
 # Check that we can use javah
-if(NOT Java_JAVAH_EXECUTABLE)
-    message(FATAL_ERROR "Cannot locate javah executable.")
-endif(NOT Java_JAVAH_EXECUTABLE)
+# if(NOT Java_JAVAH_EXECUTABLE)
+#     message(FATAL_ERROR "Cannot locate javah executable.")
+# endif(NOT Java_JAVAH_EXECUTABLE)
 
 set(CMAKE_JNI_TARGET TRUE)
 file(GLOB JAVA_SOURCES "*.java")
@@ -40,7 +44,8 @@ add_custom_command (TARGET tinybjar
   POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E echo "Generating JNI headers.."
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/tinybjar.dir"
-  COMMAND ${Java_JAVAH_EXECUTABLE} -d jni/ -jni ${JAVA_CLASSES}
+#  COMMAND ${Java_JAVAH_EXECUTABLE} -d jni/ -jni ${JAVA_CLASSES}
+  COMMAND ${JAVAC} -h jni/ ${JAVA_SOURCES}
 )
 
 set(JNI_HEADER_PATH "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/tinybjar.dir/jni")


### PR DESCRIPTION
This is a change that fixes issue of missing javah in openJDK 10+ 

I know that it is not compatible with earlier Java versions.